### PR TITLE
Add input mode parsing

### DIFF
--- a/crates/vt-push-parser/Cargo.toml
+++ b/crates/vt-push-parser/Cargo.toml
@@ -25,3 +25,8 @@ hxdmp = "0.2.1"
 name = "escapes"
 path = "tests/escapes.rs"
 harness = false
+
+[[test]]
+name = "input_escapes"
+path = "tests/input_escapes.rs"
+harness = false

--- a/crates/vt-push-parser/tests/common/mod.rs
+++ b/crates/vt-push-parser/tests/common/mod.rs
@@ -151,9 +151,6 @@ pub fn run_tests<const INTEREST: u8>(
     config: TestConfig,
     extra_validation: &(impl Fn(&str, &str, &[u8]) + std::panic::UnwindSafe + std::panic::RefUnwindSafe),
 ) {
-    println!();
-    eprintln!("Testing {}", config.input_file);
-
     let mut output = String::new();
     let mut failures = 0;
     output.push_str(&format!("# {}\n", config.title));

--- a/crates/vt-push-parser/tests/common/mod.rs
+++ b/crates/vt-push-parser/tests/common/mod.rs
@@ -1,0 +1,259 @@
+use pretty_assertions::assert_eq;
+use vt_push_parser::VTPushParser;
+use vt_push_parser::ascii::{decode_string, encode_string};
+use vt_push_parser::event::VTEvent;
+
+pub enum VTAccumulator {
+    Raw(String),
+    Esc(String),
+    Dcs(String),
+    Osc(String),
+}
+
+macro_rules! callback {
+    ($result:ident, $ret:expr) => {
+        |vt_input: VTEvent<'_>| {
+            let result = &mut $result;
+            match vt_input {
+                VTEvent::Raw(s) => {
+                    if let Some(VTAccumulator::Raw(acc)) = result.last_mut() {
+                        acc.push_str(&encode_string(s));
+                    } else {
+                        result.push(VTAccumulator::Raw(encode_string(s)));
+                    }
+                }
+                VTEvent::Csi { .. } | VTEvent::Esc { .. } | VTEvent::C0(_) => {
+                    result.push(VTAccumulator::Esc(format!("{vt_input:?}")))
+                }
+                VTEvent::Ss2 { .. } | VTEvent::Ss3 { .. } => {
+                    result.push(VTAccumulator::Esc(format!("{vt_input:?}")))
+                }
+
+                VTEvent::DcsStart { .. } => {
+                    result.push(VTAccumulator::Dcs(format!("{vt_input:?}, data=")))
+                }
+                VTEvent::DcsData(s) | VTEvent::DcsEnd(s) => {
+                    let VTAccumulator::Dcs(acc) = result.last_mut().unwrap() else {
+                        panic!("DcsData without DcsStart");
+                    };
+                    acc.push_str(&encode_string(s));
+                }
+                VTEvent::DcsCancel => {
+                    let VTAccumulator::Dcs(acc) = result.last_mut().unwrap() else {
+                        panic!("DcsCancel without DcsStart");
+                    };
+                    *acc = format!("{} (cancelled)", acc.split_once(", data=").unwrap().0);
+                }
+                VTEvent::OscStart => result.push(VTAccumulator::Osc("OscStart, data=".to_string())),
+                VTEvent::OscData(s) | VTEvent::OscEnd { data: s, .. } => {
+                    let VTAccumulator::Osc(acc) = result.last_mut().unwrap() else {
+                        panic!("OscData without OscStart");
+                    };
+                    acc.push_str(&encode_string(s));
+                }
+                VTEvent::OscCancel => {
+                    let VTAccumulator::Osc(acc) = result.last_mut().unwrap() else {
+                        panic!("OscCancel without OscStart");
+                    };
+                    *acc = format!("{} (cancelled)", acc.split_once(", data=").unwrap().0);
+                }
+            };
+            $ret
+        }
+    };
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ParseMode {
+    Normal,
+    Abortable,
+    Aborted,
+}
+
+impl ParseMode {
+    #[allow(dead_code)]
+    pub fn all() -> &'static [ParseMode] {
+        &[ParseMode::Normal, ParseMode::Abortable, ParseMode::Aborted]
+    }
+}
+
+pub fn parse<const INTEREST: u8>(mode: ParseMode, data: &[&[u8]]) -> String {
+    match mode {
+        ParseMode::Normal => parse_normal::<INTEREST>(data),
+        ParseMode::Abortable => parse_abortable::<INTEREST>(data),
+        ParseMode::Aborted => parse_aborted::<INTEREST>(data),
+    }
+}
+
+fn parse_normal<const INTEREST: u8>(data: &[&[u8]]) -> String {
+    let mut parser = VTPushParser::new_with_interest::<INTEREST>();
+    let mut result = Vec::new();
+    let mut callback = callback!(result, ());
+    for chunk in data {
+        parser.feed_with(chunk, &mut callback);
+    }
+    collect(result)
+}
+
+fn parse_abortable<const INTEREST: u8>(data: &[&[u8]]) -> String {
+    let mut parser = VTPushParser::new_with_interest::<INTEREST>();
+    let mut result = Vec::new();
+    let mut callback = callback!(result, true);
+    for chunk in data {
+        assert_eq!(
+            parser.feed_with_abortable(chunk, &mut callback),
+            chunk.len()
+        );
+    }
+    collect(result)
+}
+
+fn parse_aborted<const INTEREST: u8>(data: &[&[u8]]) -> String {
+    let mut parser = VTPushParser::new_with_interest::<INTEREST>();
+    let mut result = Vec::new();
+    let mut callback = callback!(result, false);
+    for chunk in data {
+        let mut chunk = *chunk;
+        while !chunk.is_empty() {
+            let parsed = parser.feed_with_abortable(chunk, &mut callback);
+            assert!(
+                parsed <= chunk.len(),
+                "Invalid return value for {chunk:?}: {parsed} should be <= {}",
+                chunk.len()
+            );
+            chunk = &chunk[parsed..];
+        }
+    }
+    collect(result)
+}
+
+pub fn collect(result: Vec<VTAccumulator>) -> String {
+    let mut result_string = String::new();
+    for acc in result {
+        match acc {
+            VTAccumulator::Raw(s) => result_string.push_str(&s),
+            VTAccumulator::Esc(s) => result_string.push_str(&s),
+            VTAccumulator::Dcs(s) => result_string.push_str(&s),
+            VTAccumulator::Osc(s) => result_string.push_str(&s),
+        }
+        result_string.push('\n');
+    }
+    result_string
+}
+
+pub struct TestConfig {
+    pub input_file: &'static str,
+    pub output_file: &'static str,
+    pub title: &'static str,
+}
+
+pub fn run_tests<const INTEREST: u8>(
+    config: TestConfig,
+    extra_validation: &(impl Fn(&str, &str, &[u8]) + std::panic::UnwindSafe + std::panic::RefUnwindSafe),
+) {
+    println!();
+    eprintln!("Testing {}", config.input_file);
+
+    let mut output = String::new();
+    let mut failures = 0;
+    output.push_str(&format!("# {}\n", config.title));
+
+    let filter = std::env::args().nth(1).unwrap_or_default();
+
+    let mut test_name = String::new();
+    for line in config.input_file.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(stripped_name) = line.trim().strip_prefix("# ") {
+            test_name = stripped_name.to_owned();
+            continue;
+        }
+
+        if !filter.is_empty() && !test_name.contains(&filter) {
+            continue;
+        }
+
+        let decoded = decode_string(line);
+        println!("  running {:?} ...", test_name);
+        let test_name_clone = test_name.clone();
+        let line_clone = line.to_string();
+        let Ok(test_output) = std::panic::catch_unwind(move || {
+            let mut output = String::new();
+            test::<INTEREST>(
+                &mut output,
+                &test_name_clone,
+                &line_clone,
+                &decoded,
+                extra_validation,
+            );
+            output
+        }) else {
+            eprintln!("  test {:?} panicked", test_name);
+            failures += 1;
+            continue;
+        };
+        output.push_str(&test_output);
+    }
+
+    println!();
+
+    if failures > 0 {
+        eprintln!("{} tests failed", failures);
+        std::process::exit(1);
+    }
+
+    if filter.is_empty() {
+        if std::env::var("UPDATE").is_ok() {
+            std::fs::write(config.output_file, output).unwrap();
+        } else {
+            let expected = std::fs::read_to_string(config.output_file).unwrap();
+            assert_eq!(expected, output);
+            println!("all tests passed");
+        }
+    }
+}
+
+fn test<const INTEREST: u8>(
+    output: &mut String,
+    test_name: &str,
+    line: &str,
+    decoded: &[u8],
+    extra_validation: impl Fn(&str, &str, &[u8]),
+) {
+    let result = parse::<INTEREST>(ParseMode::Normal, &[decoded]);
+
+    // Ensure the result is the same when stepping forward with a
+    // cancellable parser
+    let result_abortable = parse::<INTEREST>(ParseMode::Abortable, &[decoded]);
+    assert_eq!(result, result_abortable);
+    let result_aborted = parse::<INTEREST>(ParseMode::Aborted, &[decoded]);
+    assert_eq!(
+        result, result_aborted,
+        "Stepped parser should yield the same results"
+    );
+
+    // Ensure that the result is the same when parsing in various chunk sizes
+    for chunk_size in 1..=decoded.len() {
+        let mut byte_by_byte = Vec::new();
+        for b in decoded.chunks(chunk_size) {
+            byte_by_byte.push(b);
+        }
+        let result_byte_by_byte = parse::<INTEREST>(ParseMode::Normal, &byte_by_byte);
+        assert_eq!(
+            result,
+            result_byte_by_byte,
+            "Failed to parse in chunks of size {chunk_size} ({:02X?})",
+            decoded.chunks(chunk_size).collect::<Vec<_>>()
+        );
+    }
+
+    // Run any extra validation specific to this test configuration
+    extra_validation(test_name, &result, decoded);
+
+    output.push_str(&format!("## {test_name}\n```\n{}\n```\n\n", line));
+    output.push_str("```\n");
+    output.push_str(&result);
+    output.push_str("```\n");
+    output.push_str("---\n");
+}

--- a/crates/vt-push-parser/tests/escapes.rs
+++ b/crates/vt-push-parser/tests/escapes.rs
@@ -1,195 +1,36 @@
-use pretty_assertions::assert_eq;
-use vt_push_parser::ascii::{decode_string, encode_string};
+mod common;
+
 use vt_push_parser::event::VTEvent;
-use vt_push_parser::{VT_PARSER_INTEREST_NONE, VTPushParser};
+use vt_push_parser::{VT_PARSER_INTEREST_NONE, VT_PARSER_INTEREST_OUTPUT, VTPushParser};
 
 const INPUT: &str = include_str!("escapes.txt");
 
-enum VTAccumulator {
-    Raw(String),
-    Esc(String),
-    Dcs(String),
-    Osc(String),
-}
-
-macro_rules! callback {
-    ($result:ident, $ret:expr) => {
-        |vt_input: VTEvent<'_>| {
-            let result = &mut $result;
-            match vt_input {
-                VTEvent::Raw(s) => {
-                    if let Some(VTAccumulator::Raw(acc)) = result.last_mut() {
-                        acc.push_str(&encode_string(s));
-                    } else {
-                        result.push(VTAccumulator::Raw(encode_string(s)));
-                    }
-                }
-                VTEvent::Csi { .. } | VTEvent::Esc { .. } | VTEvent::C0(_) => {
-                    result.push(VTAccumulator::Esc(format!("{vt_input:?}")))
-                }
-                VTEvent::Ss2 { .. } | VTEvent::Ss3 { .. } => {
-                    result.push(VTAccumulator::Esc(format!("{vt_input:?}")))
-                }
-                VTEvent::DcsStart { .. } => {
-                    result.push(VTAccumulator::Dcs(format!("{vt_input:?}, data=")))
-                }
-                VTEvent::DcsData(s) | VTEvent::DcsEnd(s) => {
-                    let VTAccumulator::Dcs(acc) = result.last_mut().unwrap() else {
-                        panic!("DcsData without DcsStart");
-                    };
-                    acc.push_str(&encode_string(s));
-                }
-                VTEvent::DcsCancel => {
-                    let VTAccumulator::Dcs(acc) = result.last_mut().unwrap() else {
-                        panic!("DcsCancel without DcsStart");
-                    };
-                    *acc = format!("{} (cancelled)", acc.split_once(", data=").unwrap().0);
-                }
-                VTEvent::OscStart => result.push(VTAccumulator::Osc("OscStart, data=".to_string())),
-                VTEvent::OscData(s) | VTEvent::OscEnd { data: s, .. } => {
-                    let VTAccumulator::Osc(acc) = result.last_mut().unwrap() else {
-                        panic!("OscData without OscStart");
-                    };
-                    acc.push_str(&encode_string(s));
-                }
-                VTEvent::OscCancel => {
-                    let VTAccumulator::Osc(acc) = result.last_mut().unwrap() else {
-                        panic!("OscCancel without OscStart");
-                    };
-                    *acc = format!("{} (cancelled)", acc.split_once(", data=").unwrap().0);
-                }
-            };
-            $ret
-        }
-    };
-}
-
-#[derive(Clone, Copy, Debug)]
-enum ParseMode {
-    Normal,
-    Abortable,
-    Aborted,
-}
-
-impl ParseMode {
-    pub fn all() -> &'static [ParseMode] {
-        return &[ParseMode::Normal, ParseMode::Abortable, ParseMode::Aborted];
-    }
-}
-
-fn parse(mode: ParseMode, data: &[&[u8]]) -> String {
-    match mode {
-        ParseMode::Normal => parse_normal(data),
-        ParseMode::Abortable => parse_abortable(data),
-        ParseMode::Aborted => parse_aborted(data),
-    }
-}
-
-fn parse_normal(data: &[&[u8]]) -> String {
-    let mut parser = VTPushParser::new();
-    let mut result = Vec::new();
-    let mut callback = callback!(result, ());
-    for chunk in data {
-        parser.feed_with(chunk, &mut callback);
-    }
-    collect(result)
-}
-
-fn parse_abortable(data: &[&[u8]]) -> String {
-    let mut parser = VTPushParser::new();
-    let mut result = Vec::new();
-    let mut callback = callback!(result, true);
-    for chunk in data {
-        assert_eq!(
-            parser.feed_with_abortable(chunk, &mut callback),
-            chunk.len()
-        );
-    }
-    collect(result)
-}
-
-fn parse_aborted(data: &[&[u8]]) -> String {
-    let mut parser = VTPushParser::new();
-    let mut result = Vec::new();
-    let mut callback = callback!(result, false);
-    for chunk in data {
-        let mut chunk = *chunk;
-        while !chunk.is_empty() {
-            let parsed = parser.feed_with_abortable(chunk, &mut callback);
-            assert!(
-                parsed <= chunk.len(),
-                "Invalid return value for {chunk:?}: {parsed} should be <= {}",
-                chunk.len()
-            );
-            chunk = &chunk[parsed..];
-        }
-    }
-    collect(result)
-}
-
-fn collect(result: Vec<VTAccumulator>) -> String {
-    let mut result_string = String::new();
-    for acc in result {
-        match acc {
-            VTAccumulator::Raw(s) => result_string.push_str(&s),
-            VTAccumulator::Esc(s) => result_string.push_str(&s),
-            VTAccumulator::Dcs(s) => result_string.push_str(&s),
-            VTAccumulator::Osc(s) => result_string.push_str(&s),
-        }
-        result_string.push('\n');
-    }
-    result_string
-}
-
-fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
-    let result = parse(ParseMode::Normal, &[decoded]);
-
-    // Ensure the result is the same when stepping forward with a cancellable parser
-    let result_abortable = parse(ParseMode::Abortable, &[decoded]);
-    assert_eq!(result, result_abortable);
-    let result_aborted = parse(ParseMode::Aborted, &[decoded]);
-    assert_eq!(
-        result, result_aborted,
-        "Stepped parser should yield the same results"
-    );
-
+fn extra_validation(test_name: &str, result: &str, decoded: &[u8]) {
     // Ensure that the result is the same no matter what interest flags are set
     let mut text_content = String::new();
     let mut text_test = b"text content test:<".to_vec();
     text_test.extend_from_slice(decoded);
     text_test.extend_from_slice(b">suffix text context");
-    VTPushParser::decode_buffer(&text_test, |event| match event {
-        VTEvent::Raw(s) => text_content.push_str(String::from_utf8_lossy(s).as_ref()),
-        _ => {}
+    VTPushParser::decode_buffer(&text_test, |event| {
+        if let VTEvent::Raw(s) = event {
+            text_content.push_str(String::from_utf8_lossy(s).as_ref());
+        }
     });
 
     let mut text_content_interest_none = String::new();
     let mut parser = VTPushParser::new_with_interest::<{ VT_PARSER_INTEREST_NONE }>();
-    parser.feed_with(&text_test, &mut |event| match event {
-        VTEvent::Raw(s) => text_content_interest_none.push_str(String::from_utf8_lossy(s).as_ref()),
-        _ => {}
+    parser.feed_with(&text_test, &mut |event| {
+        if let VTEvent::Raw(s) = event {
+            text_content_interest_none.push_str(String::from_utf8_lossy(s).as_ref());
+        }
     });
     assert_eq!(text_content, text_content_interest_none);
 
-    for mode in ParseMode::all().iter().cloned() {
-        // Ensure that the result is the same when parsing in various chunk sizes
-        for chunk_size in 1..=decoded.len() {
-            let mut byte_by_byte = Vec::new();
-            for b in decoded.chunks(chunk_size) {
-                byte_by_byte.push(b);
-            }
-            let result_byte_by_byte = parse(mode, &byte_by_byte);
-            assert_eq!(
-                result,
-                result_byte_by_byte,
-                "Failed to parse in chunks of size {chunk_size} ({:02X?})",
-                decoded.chunks(chunk_size).collect::<Vec<_>>()
-            );
-        }
-
-        // Ensure that prefix and suffix to each side of the decoded data are parsed
-        // correctly. This should probably be more of a fuzz test instead.
-        let result_prefix = parse(mode, &[b"prefix", decoded]);
+    for mode in common::ParseMode::all().iter().cloned() {
+        // Ensure that prefix and suffix to each side of the decoded data are
+        // parsed correctly. This should probably be more of a fuzz test
+        // instead.
+        let result_prefix = common::parse::<VT_PARSER_INTEREST_OUTPUT>(mode, &[b"prefix", decoded]);
         let e1 = format!("prefix\n{result}");
         let e2 = format!("prefix{result}");
         if result_prefix != e1 && result_prefix != e2 {
@@ -198,7 +39,7 @@ fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
             );
         }
 
-        let result_suffix = parse(mode, &[decoded, b"suffix"]);
+        let result_suffix = common::parse::<VT_PARSER_INTEREST_OUTPUT>(mode, &[decoded, b"suffix"]);
         let e1 = format!("{result}suffix\n");
         let e2 = format!("{}suffix\n", result.trim_end());
         if result_suffix != e1 && result_suffix != e2 {
@@ -207,7 +48,8 @@ fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
             );
         }
 
-        let result_prefix = parse(mode, &["✅🛜".as_bytes(), decoded]);
+        let result_prefix =
+            common::parse::<VT_PARSER_INTEREST_OUTPUT>(mode, &["✅🛜".as_bytes(), decoded]);
         let e1 = format!("✅🛜\n{result}");
         let e2 = format!("✅🛜{result}");
         if result_prefix != e1 && result_prefix != e2 {
@@ -226,7 +68,7 @@ fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
     {
         let mut re_encoded = Vec::new();
         let mut raw_del = false;
-        VTPushParser::decode_buffer(&decoded, |event| {
+        VTPushParser::decode_buffer(decoded, |event| {
             let mut buffer = [0_u8; 1024];
             let n = event.encode(&mut buffer).unwrap();
             re_encoded.extend_from_slice(&buffer[..n]);
@@ -239,7 +81,7 @@ fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
             decoded.to_vec()
         } else {
             decoded
-                .into_iter()
+                .iter()
                 .cloned()
                 .filter(|b| *b != 0x7F)
                 .collect::<Vec<_>>()
@@ -250,68 +92,15 @@ fn test(output: &mut String, test_name: &str, line: &str, decoded: &[u8]) {
             );
         }
     }
-
-    output.push_str(&format!("## {test_name}\n```\n{}\n```\n\n", line));
-    output.push_str("```\n");
-    output.push_str(&result);
-    output.push_str("```\n");
-    output.push_str("---\n");
 }
 
 pub fn main() {
-    println!();
-    eprintln!("Testing escapes.txt");
-
-    let mut output = String::new();
-    let mut failures = 0;
-    output.push_str("# Escapes\n");
-
-    let filter = std::env::args().nth(1).unwrap_or_default();
-
-    let mut test_name = String::new();
-    for line in INPUT.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        if let Some(stripped_name) = line.strip_prefix("# ") {
-            test_name = stripped_name.to_owned();
-            continue;
-        }
-
-        if !filter.is_empty() && !test_name.contains(&filter) {
-            continue;
-        }
-
-        let decoded = decode_string(line);
-        println!("  running {:?} ...", test_name);
-        let test_name_clone = test_name.clone();
-        let Ok(test_output) = std::panic::catch_unwind(move || {
-            let mut output = String::new();
-            test(&mut output, &test_name_clone, line, &decoded);
-            output
-        }) else {
-            eprintln!("  test {:?} panicked", test_name);
-            failures += 1;
-            continue;
-        };
-        output.push_str(&test_output);
-    }
-
-    println!();
-
-    if failures > 0 {
-        eprintln!("{} tests failed", failures);
-        std::process::exit(1);
-    }
-
-    if filter.is_empty() {
-        if std::env::var("UPDATE").is_ok() {
-            std::fs::write("tests/result.md", output).unwrap();
-        } else {
-            let expected = std::fs::read_to_string("tests/result.md").unwrap();
-            assert_eq!(expected, output);
-            println!("all tests passed");
-        }
-    }
+    common::run_tests::<VT_PARSER_INTEREST_OUTPUT>(
+        common::TestConfig {
+            input_file: INPUT,
+            output_file: "tests/result.md",
+            title: "Escapes",
+        },
+        &extra_validation,
+    );
 }

--- a/crates/vt-push-parser/tests/input_escapes.rs
+++ b/crates/vt-push-parser/tests/input_escapes.rs
@@ -1,0 +1,21 @@
+mod common;
+
+use vt_push_parser::VT_PARSER_INTEREST_INPUT;
+
+const INPUT: &str = include_str!("input_escapes.txt");
+
+fn extra_validation(_test_name: &str, _result: &str, _decoded: &[u8]) {
+    // Input mode tests don't need the extra validation that output mode
+    // tests do (prefix/suffix tests, re-encoding checks, etc.)
+}
+
+pub fn main() {
+    common::run_tests::<VT_PARSER_INTEREST_INPUT>(
+        common::TestConfig {
+            input_file: INPUT,
+            output_file: "tests/input_result.md",
+            title: "Input Escapes",
+        },
+        &extra_validation,
+    );
+}

--- a/crates/vt-push-parser/tests/input_escapes.txt
+++ b/crates/vt-push-parser/tests/input_escapes.txt
@@ -1,0 +1,68 @@
+# ESC space (Alt+space)
+<ESC><SP>
+
+# ESC ! (Alt+!)
+<ESC>!
+
+# ESC ( (Alt+()
+<ESC>(
+
+# ESC / (Alt+/, last intermediate character)
+<ESC>/
+
+# ESC ? (Alt+?)
+<ESC>?
+
+# ESC > (Alt+>)
+<ESC>>
+
+# ESC 1 (Alt+1)
+<ESC>1
+
+# ESC M (Alt+M)
+<ESC>M
+
+# ESC N (Alt+N, NOT SS2 in input mode)
+<ESC>N
+
+# ESC a (Alt+a)
+<ESC>a
+
+# Alt+Enter (ESC \r)
+<ESC><CR>
+
+# Alt+Tab (ESC \t)
+<ESC><TAB>
+
+# Alt+Newline (ESC \n)
+<ESC><LF>
+
+# ESC [ A (Up arrow - CSI sequence)
+<ESC>[A
+
+# ESC O P (F1 - SS3 sequence)
+<ESC>OP
+
+# ESC ESC (Alt+ESC)
+<ESC><ESC>
+
+# ESC ESC [A (Alt+ESC followed by raw text [A)
+<ESC><ESC>[A
+
+# ESC CAN (Alt+Ctrl+x)
+<ESC><CAN>
+
+# ESC SUB (Alt+Ctrl+z)
+<ESC><SUB>
+
+# ESC DEL (Alt+Backspace)
+<ESC><DEL>
+
+# Multiple Alt+key sequences in a row
+<ESC>a<ESC>b<ESC>c
+
+# Alt+key mixed with regular text
+hello<ESC>aworld
+
+# ESC followed by various C0 controls
+<ESC><NUL><ESC><SOH><ESC><STX>

--- a/crates/vt-push-parser/tests/input_result.md
+++ b/crates/vt-push-parser/tests/input_result.md
@@ -1,0 +1,215 @@
+# Input Escapes
+## ESC space (Alt+space)
+```
+<ESC><SP>
+```
+
+```
+Esc('',  )
+```
+---
+## ESC ! (Alt+!)
+```
+<ESC>!
+```
+
+```
+Esc('', !)
+```
+---
+## ESC ( (Alt+()
+```
+<ESC>(
+```
+
+```
+Esc('', ()
+```
+---
+## ESC / (Alt+/, last intermediate character)
+```
+<ESC>/
+```
+
+```
+Esc('', /)
+```
+---
+## ESC ? (Alt+?)
+```
+<ESC>?
+```
+
+```
+Esc('', ?)
+```
+---
+## ESC > (Alt+>)
+```
+<ESC>>
+```
+
+```
+Esc('', >)
+```
+---
+## ESC 1 (Alt+1)
+```
+<ESC>1
+```
+
+```
+Esc('', 1)
+```
+---
+## ESC M (Alt+M)
+```
+<ESC>M
+```
+
+```
+Esc('', M)
+```
+---
+## ESC N (Alt+N, NOT SS2 in input mode)
+```
+<ESC>N
+```
+
+```
+Esc('', N)
+```
+---
+## ESC a (Alt+a)
+```
+<ESC>a
+```
+
+```
+Esc('', a)
+```
+---
+## Alt+Enter (ESC \r)
+```
+<ESC><CR>
+```
+
+```
+Esc('', <CR>)
+```
+---
+## Alt+Tab (ESC \t)
+```
+<ESC><TAB>
+```
+
+```
+Esc('', <TAB>)
+```
+---
+## Alt+Newline (ESC \n)
+```
+<ESC><LF>
+```
+
+```
+Esc('', <LF>)
+```
+---
+## ESC [ A (Up arrow - CSI sequence)
+```
+<ESC>[A
+```
+
+```
+Csi(, '', 'A')
+```
+---
+## ESC O P (F1 - SS3 sequence)
+```
+<ESC>OP
+```
+
+```
+Ss3('P')
+```
+---
+## ESC ESC (Alt+ESC)
+```
+<ESC><ESC>
+```
+
+```
+Esc('', <ESC>)
+```
+---
+## ESC ESC [A (Alt+ESC followed by raw text [A)
+```
+<ESC><ESC>[A
+```
+
+```
+Esc('', <ESC>)
+[A
+```
+---
+## ESC CAN (Alt+Ctrl+x)
+```
+<ESC><CAN>
+```
+
+```
+Esc('', <CAN>)
+```
+---
+## ESC SUB (Alt+Ctrl+z)
+```
+<ESC><SUB>
+```
+
+```
+Esc('', <SUB>)
+```
+---
+## ESC DEL (Alt+Backspace)
+```
+<ESC><DEL>
+```
+
+```
+Esc('', <DEL>)
+```
+---
+## Multiple Alt+key sequences in a row
+```
+<ESC>a<ESC>b<ESC>c
+```
+
+```
+Esc('', a)
+Esc('', b)
+Esc('', c)
+```
+---
+## Alt+key mixed with regular text
+```
+hello<ESC>aworld
+```
+
+```
+hello
+Esc('', a)
+world
+```
+---
+## ESC followed by various C0 controls
+```
+<ESC><NUL><ESC><SOH><ESC><STX>
+```
+
+```
+Esc('', <NUL>)
+Esc('', <SOH>)
+Esc('', <STX>)
+```
+---


### PR DESCRIPTION
Add `VT_PARSER_INTEREST_INPUT` flag to parse keyboard input escape
sequences (Alt+key, SS2/SS3, etc.) which differ from output mode.
